### PR TITLE
Include kwargs when generating signature

### DIFF
--- a/lib/delayed_duplicate_prevention_plugin.rb
+++ b/lib/delayed_duplicate_prevention_plugin.rb
@@ -49,7 +49,7 @@ class DelayedDuplicatePreventionPlugin < Delayed::Plugin
         end
       end
       if payload_object.respond_to?(:method_name)
-        sig += "##{pobj.method_name}" unless sig.match("##{pobj.method_name}")
+        sig += "##{payload_object.method_name}" unless sig.match("##{payload_object.method_name}")
       end
       sig
     end

--- a/lib/delayed_duplicate_prevention_plugin.rb
+++ b/lib/delayed_duplicate_prevention_plugin.rb
@@ -36,7 +36,8 @@ class DelayedDuplicatePreventionPlugin < Delayed::Plugin
     def generate_signature_for_job_payload
       if payload_object.respond_to?(:signature)
         if payload_object.method(:signature).arity > 0
-          sig = payload_object.signature(payload_object.method_name, payload_object.args)
+          combined_args = [payload_object.args, payload_object.kwargs]
+          sig = payload_object.signature(payload_object.method_name, combined_args)
         else
           sig = payload_object.signature
         end


### PR DESCRIPTION
Also fixes an obsolete variable reference.

Note on signature method's signature: 
The `signature` method's basic parameter signature has been preserved for better backward compatibility - by wrapping positional and keyword args into a single higher-level array parameter (instead of passing kwargs as the third argument). The signature definitions in the app have also been updated accordingly in the corresponding PR to deduce appropriately from the new combined array format.