### PR TITLE
Make signature unique for class methods

### DIFF
--- a/lib/delayed_duplicate_prevention_plugin.rb
+++ b/lib/delayed_duplicate_prevention_plugin.rb
@@ -41,7 +41,12 @@ class DelayedDuplicatePreventionPlugin < Delayed::Plugin
         obj.respond_to?(:id) ? "#{obj.class}:#{obj.id}" : obj.to_s
       end
 
-      "#{payload_object.object}##{payload_object.method_name}-#{arg_signatures}"
+      kwarg_signatures = get_kwargs.map do |(key, val)|
+        val = val.respond_to?(:id) ? "#{val.class}:#{val.id}" : val.to_s
+        [key, val]
+      end.to_h
+
+      "#{payload_object.object}##{payload_object.method_name}-#{arg_signatures}-#{kwarg_signatures}"
     end
 
     # Methods tagged with handle_asynchronously

--- a/lib/delayed_duplicate_prevention_plugin.rb
+++ b/lib/delayed_duplicate_prevention_plugin.rb
@@ -31,7 +31,7 @@ class DelayedDuplicatePreventionPlugin < Delayed::Plugin
           generate_signature_random
         end
       rescue
-        generate_signature_failed
+        log_signature_failed
       end
     end
 
@@ -80,8 +80,8 @@ class DelayedDuplicatePreventionPlugin < Delayed::Plugin
       SecureRandom.uuid
     end
 
-    def generate_signature_failed
-      puts "DelayedDuplicatePreventionPlugin could not generate the signature correctly."
+    def log_signature_failed
+      Rails.logger.error "DelayedDuplicatePreventionPlugin could not generate the signature correctly."
     end
 
     def get_args

--- a/lib/delayed_duplicate_prevention_plugin.rb
+++ b/lib/delayed_duplicate_prevention_plugin.rb
@@ -130,8 +130,8 @@ class DelayedDuplicatePreventionPlugin < Delayed::Plugin
     end
 
     def args_match?(job1, job2)
-      job1.payload_object.try(:args) == job2.payload_object.try(:args) &&
-        job1.payload_object.try(:kwargs) == job2.payload_object.try(:kwargs)
+      job1.payload_object.args == job2.payload_object.args &&
+        job1.payload_object.kwargs == job2.payload_object.kwargs
     rescue
       false
     end


### PR DESCRIPTION
Tasks
- Make signature unique for class methods by factoring args.
- Refactor:
  - Use logger instead of puts for the failed case and rename method.
  - Extend defensive args handling done in existing code to kwargs (that was implemented recently).